### PR TITLE
fixed inconsistent output issue

### DIFF
--- a/src/BikramSambat.test.ts
+++ b/src/BikramSambat.test.ts
@@ -93,6 +93,11 @@ describe('BikramSambat Class', () => {
       expect(bikramSambat.toAD().toISOString().slice(0, 10)).toBe(adDate)
     })
   })
+  it('should properly convert dates to BikramSambat using both instance and static methods', () => {
+    const bsDateFromInstance = new BikramSambat().toString()
+    const bsDateFromStaticMethod = BikramSambat.fromAD(new Date()).toString();
+    expect(bsDateFromInstance).toEqual(bsDateFromStaticMethod)
+  })
   it('should properly convert to BikramSambat Date', () => {
     sampleData.forEach(([bsDate, adDate]) => {
       expect(BikramSambat.fromAD(adDate).toString()).toBe(bsDate)

--- a/src/BikramSambat.ts
+++ b/src/BikramSambat.ts
@@ -181,7 +181,16 @@ export class BikramSambat {
     if (!date) {
       return new BikramSambat()
     }
+
     const gregorianDate = new Date(date)
+
+    // Ensure the date is normalized to midnight UTC
+    gregorianDate.setUTCHours(0, 0, 0, 0)
+
+    if (isNaN(gregorianDate.getTime())) {
+      return new BikramSambat(InvalidDate)
+    }
+
     if (gregorianDate.toString() === InvalidDate) {
       return new BikramSambat(InvalidDate)
     }

--- a/src/BikramSambat.ts
+++ b/src/BikramSambat.ts
@@ -184,13 +184,10 @@ export class BikramSambat {
 
     const gregorianDate = new Date(date)
 
-    if (isNaN(gregorianDate.getTime())) {
+    if (isNaN(gregorianDate.getTime()) || gregorianDate.toString() === InvalidDate) {
       return new BikramSambat(InvalidDate)
     }
 
-    if (gregorianDate.toString() === InvalidDate) {
-      return new BikramSambat(InvalidDate)
-    }
     const { newYearDate, bsYear } = getNewYearDateInfo(gregorianDate)
     const daysFromNewYear = getDaysBetweenTwoAdDates(
       gregorianDate,

--- a/src/BikramSambat.ts
+++ b/src/BikramSambat.ts
@@ -49,7 +49,7 @@ export class BikramSambat {
       this.month = dateStr.getMonth()
       this.day = dateStr.getDay()
     } else {
-      const currentDate = new Date().toISOString().slice(0, 10)
+      const currentDate = new Date()
       const currentBsDate = BikramSambat.fromAD(currentDate)
       this.year = currentBsDate.getYear()
       this.month = currentBsDate.getMonth()
@@ -183,9 +183,6 @@ export class BikramSambat {
     }
 
     const gregorianDate = new Date(date)
-
-    // Ensure the date is normalized to midnight UTC
-    gregorianDate.setUTCHours(0, 0, 0, 0)
 
     if (isNaN(gregorianDate.getTime())) {
       return new BikramSambat(InvalidDate)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import { BikramSambat } from './BikramSambat'
 
+
 export default BikramSambat

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 import { BikramSambat } from './BikramSambat'
 
-
 export default BikramSambat

--- a/src/utils/getDaysBetweenTwoAdDates.test.ts
+++ b/src/utils/getDaysBetweenTwoAdDates.test.ts
@@ -18,4 +18,11 @@ describe('getDaysBetweenTwoAdDates', () => {
     const endDate = new Date('2023-08-15')
     expect(getDaysBetweenTwoAdDates(startDate, endDate)).toBe(0)
   })
+
+  it('calculates the correct number of days ignoring partial days', () => {
+    const startDate = new Date();
+    const endDate = new Date();
+    endDate.setMinutes(startDate.getMinutes() + 5); // Add 5 minutes
+    expect(getDaysBetweenTwoAdDates(startDate, endDate)).toBe(0)
+  })
 })

--- a/src/utils/getDaysBetweenTwoAdDates.ts
+++ b/src/utils/getDaysBetweenTwoAdDates.ts
@@ -2,6 +2,6 @@ const MILLISECONDS_IN_A_DAY = 1000 * 60 * 60 * 24
 
 export const getDaysBetweenTwoAdDates = (startDate: Date, endDate: Date) => {
   const timeDiff = Math.abs(endDate.getTime() - startDate.getTime())
-  const diffDays = Math.ceil(timeDiff / MILLISECONDS_IN_A_DAY)
+  const diffDays = Math.floor(timeDiff / MILLISECONDS_IN_A_DAY)
   return diffDays
 }


### PR DESCRIPTION
### Description

In addressing a problem, I discovered that:

new BikramSambat()
BikramSambat.fromAD(new Date())
were producing inconsistent results.

The issue arose because, when creating a new instance of BikramSambat, the current date was converted to an ISO string and then sliced to reset the UTC hours to 00:00:00. However, when using the static method directly (BikramSambat.fromAD(new Date())), the UTC handling led to slight discrepancies, causing the date calculation to be offset by one day.

### Issue Reference

Inconsistent output https://github.com/askbuddie/bikram-sambat/issues/48

### Proposed Changes

To ensure consistent results between both approaches, I've applied uniform UTC handling for date calculations, maintaining the same logic for resetting the date to 00:00:00 in UTC.

### Screenshots / GIFs / Videos


### Checklist

- [x] Lint rules are passed correctly
- [x] Code builds correctly
- [x] Created or updated tests for the new code
- [x] All existing and new tests passed
- [x] Pull request title is concise and descriptive.
- [x] Pull request is linked to the related issue.
